### PR TITLE
Fixes after HZI merge

### DIFF
--- a/sormas-backend/src/main/resources/sql/sormas_schema.sql
+++ b/sormas-backend/src/main/resources/sql/sormas_schema.sql
@@ -4622,53 +4622,6 @@ UPDATE cases SET surveillanceofficer_id = null FROM users WHERE cases.surveillan
 
 INSERT INTO schema_version (version_number, comment) VALUES (215, 'Remove wrongly assigned surveillance officers from cases #2284');
 
--- 2020-06-09 Add origin of the source of an event
-
-ALTER TABLE events ADD COLUMN srcorigin character varying(512);
-ALTER TABLE events_history ADD COLUMN srcorigin character varying(512);
-
-INSERT INTO schema_version (version_number, comment) VALUES (216, 'Adds the field origin of the source of an event');
-
--- 2020-06-10 Add actions
-
-CREATE TABLE action (
-id bigint not null,
-reply varchar(4096),
-changedate timestamp not null,
-creationdate timestamp not null,
-description varchar(4096),
-date timestamp,
-statuschangedate timestamp,
-actioncontext varchar(512),
-actionstatus varchar(512),
-uuid varchar(36) not null unique,
-event_id bigint,
-creatoruser_id bigint,
-priority varchar(512),
-sys_period tstzrange not null,
-PRIMARY KEY (id));
-
-ALTER TABLE action OWNER TO sormas_user;
-
-ALTER TABLE action ADD CONSTRAINT fk_action_event_id FOREIGN KEY (event_id) REFERENCES events (id);
-ALTER TABLE action ADD CONSTRAINT fk_action_creatoruser_id FOREIGN KEY (creatoruser_id) REFERENCES users (id);
-
-UPDATE action SET sys_period=tstzrange(creationdate, null);
-ALTER TABLE action ALTER COLUMN sys_period SET NOT NULL;
-CREATE TABLE action_history (LIKE action);
-CREATE TRIGGER versioning_trigger
-BEFORE INSERT OR UPDATE OR DELETE ON action
-FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'action_history', true);
-ALTER TABLE action_history OWNER TO sormas_user;
-
-INSERT INTO schema_version (version_number, comment) VALUES (217, 'Adds actions to events');
-
--- 2020-06-18 Add type of risk of an event
-ALTER TABLE events ADD COLUMN typeofrisk character varying(255);
-ALTER TABLE events_history ADD COLUMN typeofrisk character varying(255);
-INSERT INTO schema_version (version_number, comment) VALUES (218, 'Add field type of risk of an event');
-
--- *** Insert new sql commands BEFORE this line ***
 -- 2020-06-18 Add campaign forms #2268
 CREATE TABLE campaignforms(
 	id bigint not null,
@@ -4715,5 +4668,51 @@ ALTER TABLE region ADD COLUMN area_id bigint;
 ALTER TABLE region ADD CONSTRAINT fk_region_area_id FOREIGN KEY (area_id) REFERENCES areas(id);
 
 INSERT INTO schema_version (version_number, comment) VALUES (217, 'Add Area as new infrastructure type #1983');
+
+-- 2020-06-09 Add origin of the source of an event
+
+ALTER TABLE events ADD COLUMN srcorigin character varying(512);
+ALTER TABLE events_history ADD COLUMN srcorigin character varying(512);
+
+INSERT INTO schema_version (version_number, comment) VALUES (218, 'Adds the field origin of the source of an event');
+
+-- 2020-06-10 Add actions
+
+CREATE TABLE action (
+id bigint not null,
+reply varchar(4096),
+changedate timestamp not null,
+creationdate timestamp not null,
+description varchar(4096),
+date timestamp,
+statuschangedate timestamp,
+actioncontext varchar(512),
+actionstatus varchar(512),
+uuid varchar(36) not null unique,
+event_id bigint,
+creatoruser_id bigint,
+priority varchar(512),
+sys_period tstzrange not null,
+PRIMARY KEY (id));
+
+ALTER TABLE action OWNER TO sormas_user;
+
+ALTER TABLE action ADD CONSTRAINT fk_action_event_id FOREIGN KEY (event_id) REFERENCES events (id);
+ALTER TABLE action ADD CONSTRAINT fk_action_creatoruser_id FOREIGN KEY (creatoruser_id) REFERENCES users (id);
+
+UPDATE action SET sys_period=tstzrange(creationdate, null);
+ALTER TABLE action ALTER COLUMN sys_period SET NOT NULL;
+CREATE TABLE action_history (LIKE action);
+CREATE TRIGGER versioning_trigger
+    BEFORE INSERT OR UPDATE OR DELETE ON action
+    FOR EACH ROW EXECUTE PROCEDURE versioning('sys_period', 'action_history', true);
+ALTER TABLE action_history OWNER TO sormas_user;
+
+INSERT INTO schema_version (version_number, comment) VALUES (219, 'Adds actions to events');
+
+-- 2020-06-18 Add type of risk of an event
+ALTER TABLE events ADD COLUMN typeofrisk character varying(255);
+ALTER TABLE events_history ADD COLUMN typeofrisk character varying(255);
+INSERT INTO schema_version (version_number, comment) VALUES (220, 'Add field type of risk of an event');
 
 -- *** Insert new sql commands BEFORE this line ***

--- a/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventActionsView.java
+++ b/sormas-ui/src/main/java/de/symeda/sormas/ui/events/EventActionsView.java
@@ -101,13 +101,24 @@ public class EventActionsView extends AbstractEventView {
 		return filterLayout;
 	}
 
-	@Override
-	public void enter(ViewChangeEvent event) {
-		if (event != null) {
-			super.enter(event);
-		}
+	/**
+	 * Update filter form values.
+	 */
+	private void updateFilterComponents() {
+		// disable triggers on value change
+		applyingCriteria = true;
+		filterForm.setValue(criteria);
+		applyingCriteria = false;
+	}
 
-		String params = event.getParameters().trim();
+	/**
+	 * Reload datas in the list.
+	 */
+	private void reload() {
+		list.reload();
+	}
+
+	@Override protected void initView(String params) {
 		if (params.contains("?")) {
 			criteria.fromUrlParams(params.substring(params.indexOf("?") + 1));
 		}
@@ -129,22 +140,5 @@ public class EventActionsView extends AbstractEventView {
 		updateFilterComponents();
 
 		reload();
-	}
-
-	/**
-	 * Update filter form values.
-	 */
-	private void updateFilterComponents() {
-		// disable triggers on value change
-		applyingCriteria = true;
-		filterForm.setValue(criteria);
-		applyingCriteria = false;
-	}
-
-	/**
-	 * Reload datas in the list.
-	 */
-	private void reload() {
-		list.reload();
 	}
 }


### PR DESCRIPTION
Il est important de garder le fomat de fichier suivant pour le script SQL, cela permet de gérer le versionning du schéma et de mettre à jour le schéma au démarrage :

- comandes SQL (peuvent être sur plusieurs lignes)
- `INSERT INTO schema_version (version_number, comment) VALUES (XXX, 'blabla');` enregistrement de ce patch SQL dans la table `schema_version` qui permet de savoir 
- dernière ligne du fichier : `-- *** Insert new sql commands BEFORE this line ***`

Il est à noter qu'au démarrage de l'application, les patches (ensembles de commandes SQL avant la ligne `INSERT INTO schema_version (…)`) non enregistrés dans `schema_version` sont exécutés.
Lors du déploiement de cette version sur le serveur de test, la migration du schéma de base de données ne pourra pas s'effectuer correctement.
En effet, la version GRADeS précédente a enregistré les patchs 216 à 218, ils ont maintenant les numéros 218 à 220. Cela vient du fait que la version HZI a également défini les version 216 et 217.
Il faudra donc corriger le schéma de la base de données et appliquer les scripts de migration manuellement (avec les bons numéros de version).