### PR TITLE
Duplication de la fonction "gestion des doublons" pour les contacts - modification #18

### DIFF
--- a/sormas-backend/src/main/java/de/symeda/sormas/backend/contact/ContactFacadeEjb.java
+++ b/sormas-backend/src/main/java/de/symeda/sormas/backend/contact/ContactFacadeEjb.java
@@ -1294,6 +1294,9 @@ public class ContactFacadeEjb implements ContactFacade {
 				FacadeProvider.getConfigFacade().getNameSimilarityThreshold());
 		Predicate diseaseFilter = cb.equal(root.get(Contact.DISEASE), root2.get(Contact.DISEASE));
 		Predicate regionFilter = cb.equal(region.get(Region.ID), region2.get(Region.ID));
+
+		Predicate cazeFilter = cb.equal(root.get(Contact.CAZE),root2.get(Contact.CAZE));
+
 		Predicate reportDateFilter = cb.lessThanOrEqualTo(
 				cb.abs(
 						cb.diff(
@@ -1335,6 +1338,13 @@ public class ContactFacadeEjb implements ContactFacade {
 		} else {
 			filter = nameSimilarityFilter;
 		}
+
+		if (filter != null) {
+			filter = cb.and(filter, cazeFilter);
+		} else {
+			filter = cazeFilter;
+		}
+
 		filter = cb.and(filter, diseaseFilter);
 
 		if (!showDuplicatesWithDifferentRegion) {


### PR DESCRIPTION
**Duplication de la fonction "gestion des doublons" pour les contacts - modification** #18 

Ne plus proposer une fusion de doublons de contacts lorsque les deux contacts en question ne sont pas rattachés au même cas.